### PR TITLE
MO-48-Add-security-group-to-Pivot-view-in-resource

### DIFF
--- a/resource_reservation/views/menu.xml
+++ b/resource_reservation/views/menu.xml
@@ -25,6 +25,12 @@
               parent="menu_resource_reservation"
               action="action_resource_availability"/>
 
+    <menuitem id="resource_reservation_pivot"
+              name="Reports"
+              parent="menu_resource_reservation"
+              action="action_resource_reservation_act_pivot_window"
+              groups="group_resource_reservation_approver"/>
+
     <menuitem id="menu_reservation_tag"
               name="Reservation Tags"
               parent="menu_resource_configurations"

--- a/resource_reservation/views/resource_reservation_views.xml
+++ b/resource_reservation/views/resource_reservation_views.xml
@@ -153,8 +153,16 @@
             model="ir.actions.act_window">
         <field name="name">Resource Reservation</field>
         <field name="res_model">resource.reservation</field>
-        <field name="view_mode">tree,form,calendar,pivot</field>
+        <field name="view_mode">tree,form,calendar</field>
         <field name="search_view_id" ref="resource_reservation_view_search"/>
+        <field name="context">{'no_breadcrumbs': True}</field>
+    </record>
+
+        <record id="action_resource_reservation_act_pivot_window"
+            model="ir.actions.act_window">
+        <field name="name">Resource Reservation</field>
+        <field name="res_model">resource.reservation</field>
+        <field name="view_mode">pivot</field>
         <field name="context">{'no_breadcrumbs': True}</field>
     </record>
 </odoo>


### PR DESCRIPTION
[ADD] menu

added reports menu for pivot

only approver and admin can see it

Ran pylint and flake8. there are 4 errors from previous development and they are difficult to fix