### PR TITLE
MO-53-In-resource-reservation-currently-users-and-aprovers-can-create-reservation-tags-when-creating-a-new-reservation

### DIFF
--- a/resource_reservation/views/resource_availability.xml
+++ b/resource_reservation/views/resource_availability.xml
@@ -8,7 +8,7 @@
             <form create="false">
                 <sheet>
                     <group>
-                        <field name="resource_id"/>
+                        <field name="resource_id" options="{'no_create': True}"/>
                         <field name="start_datetime"/>
                         <field name="end_datetime"/>
                         <field name="availability_status" readonly="1"/>

--- a/resource_reservation/views/resource_reservation_views.xml
+++ b/resource_reservation/views/resource_reservation_views.xml
@@ -50,7 +50,8 @@
                     <group>
                         <group>
                             <field name="reservation_tag_id"
-                                   widget="many2many_tags"/>
+                                   widget="many2many_tags"
+                                   options="{'no_create': True}"/>
                         </group>
 
                     </group>
@@ -135,7 +136,8 @@
         <field name="name">resource.reservation.calendar</field>
         <field name="model">resource.reservation</field>
         <field name="arch" type="xml">
-            <calendar string="Resource Reservation Calendar" date_start="start_datetime" color="color_reserv" event_open_popup="false" quick_add="false">
+            <calendar string="Resource Reservation Calendar" date_start="start_datetime" color="color_reserv"
+                      event_open_popup="false" quick_add="false">
                 <field name="title" width="4"/>
                 <field name="resource_name" width="4" filters="1"/>
                 <field name="start_datetime" width="4"/>
@@ -158,7 +160,7 @@
         <field name="context">{'no_breadcrumbs': True}</field>
     </record>
 
-        <record id="action_resource_reservation_act_pivot_window"
+    <record id="action_resource_reservation_act_pivot_window"
             model="ir.actions.act_window">
         <field name="name">Resource Reservation</field>
         <field name="res_model">resource.reservation</field>

--- a/resource_reservation/views/resource_views.xml
+++ b/resource_reservation/views/resource_views.xml
@@ -1,145 +1,158 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <odoo>
-        <record id="view_resource_tree" model="ir.ui.view">
-            <field name="name">resource.tree</field>
-            <field name="model">resource</field>
-            <field name="arch" type="xml">
-                <tree name="Resource">
-                    <field name="name" width="6"/>
-                    <field name="resource_type" width="6"/>
-                    <field name="resource_capacity" invisible="1"/>
-                    <field name="resource_capacity_text" width="6"/>
-                    <field name="resource_owner" width="6"/>
-                </tree>
-            </field>
-        </record>
+    <record id="view_resource_tree" model="ir.ui.view">
+        <field name="name">resource.tree</field>
+        <field name="model">resource</field>
+        <field name="arch" type="xml">
+            <tree name="Resource">
+                <field name="name" width="6"/>
+                <field name="resource_type" width="6"/>
+                <field name="resource_capacity" invisible="1"/>
+                <field name="resource_capacity_text" width="6"/>
+                <field name="resource_owner" width="6"/>
+            </tree>
+        </field>
+    </record>
 
-        <record model="ir.ui.view" id="view_resource_form">
-            <field name="name">resource.form</field>
-            <field name="model">resource</field>
-            <field name="arch" type="xml">
-                <form name="Resource" create="false">
-                    <sheet>
+    <record model="ir.ui.view" id="view_resource_form">
+        <field name="name">resource.form</field>
+        <field name="model">resource</field>
+        <field name="arch" type="xml">
+            <form name="Resource" create="false">
+                <sheet>
+                    <group>
                         <group>
-                            <group>
-                                <field name="name" required="1"/>
-                                <field name="resource_type" required="1"/>
-                                <field name="resource_capacity" required="1"/>
-                                <field name="resource_owner" required="1" options="{'no_create': True}"/>
-                                <field name="resource_tags" required="1" widget="many2many_tags"/>
-                                <field name="resource_capacity_text" invisible="1"/>
-                            </group>
-                            <group>
-                                <field name="image" widget="image" class="oe_avatar" filename="name"/>
-                            </group>
-                            <notebook>
-                                <page string="Confirmed Reservations">
-                                    <field name="confirmed_reservations" mode="tree">
-                                        <tree>
-                                            <field name="name"/>
-                                            <field name="booking_status"/>
-                                        </tree>
-                                    </field>
-                                </page>
-                                <page string="Cancelled Reservations">
-                                    <field name="cancelled_reservations" mode="tree">
-                                        <tree>
-                                            <field name="name"/>
-                                            <field name="booking_status"/>
-                                        </tree>
-                                    </field>
-                                </page>
-                            </notebook>
+                            <field name="name"
+                                   required="1"/>
+                            <field name="resource_type"
+                                   required="1"
+                                   options="{'no_create': True}"/>
+                            <field name="resource_capacity"
+                                   required="1"/>
+                            <field name="resource_owner"
+                                   required="1"
+                                   options="{'no_create': True}"/>
+                            <field name="resource_tags"
+                                   required="1"
+                                   widget="many2many_tags"
+                                   options="{'no_create': True}"/>
+                            <field name="resource_capacity_text"
+                                   invisible="1"/>
                         </group>
-                    </sheet>
-                </form>
-            </field>
-        </record>
-
-        <record id="view_resource_type_tree" model="ir.ui.view">
-            <field name="name">resource.type.tree</field>
-            <field name="model">resource.type</field>
-            <field name="arch" type="xml">
-                <tree name="Resource Types" editable="top">
-                    <field name="name"/>
-                    <field name="color_resource_type" widget="color_picker"/>
-                </tree>
-            </field>
-        </record>
-
-        <record id="view_resource_type_form" model="ir.ui.view">
-            <field name="name">resource.type.form</field>
-            <field name="model">resource.type</field>
-            <field name="arch" type="xml">
-                <form string="Resource Type" create="false">
-                    <sheet>
                         <group>
-                            <field name="name"/>
-                            <field name="color_resource_type" widget="color_picker"/>
+                            <field name="image"
+                                   widget="image"
+                                   class="oe_avatar"
+                                   filename="name"/>
                         </group>
-                    </sheet>
-                </form>
-            </field>
-        </record>
+                        <notebook>
+                            <page string="Confirmed Reservations">
+                                <field name="confirmed_reservations" mode="tree">
+                                    <tree>
+                                        <field name="name"/>
+                                        <field name="booking_status"/>
+                                    </tree>
+                                </field>
+                            </page>
+                            <page string="Cancelled Reservations">
+                                <field name="cancelled_reservations" mode="tree">
+                                    <tree>
+                                        <field name="name"/>
+                                        <field name="booking_status"/>
+                                    </tree>
+                                </field>
+                            </page>
+                        </notebook>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
 
-        <record id="view_resource_tag_tree" model="ir.ui.view">
-            <field name="name">resource.tag.tree</field>
-            <field name="model">resource.tag</field>
-            <field name="arch" type="xml">
-                <tree name="Resource Tags" editable="top">
-                    <field name="name"/>
-                </tree>
-            </field>
-        </record>
+    <record id="view_resource_type_tree" model="ir.ui.view">
+        <field name="name">resource.type.tree</field>
+        <field name="model">resource.type</field>
+        <field name="arch" type="xml">
+            <tree name="Resource Types" editable="top">
+                <field name="name"/>
+                <field name="color_resource_type" widget="color_picker"/>
+            </tree>
+        </field>
+    </record>
 
-        <record id="view_resource_tag_form" model="ir.ui.view">
-            <field name="name">resource.tag.form</field>
-            <field name="model">resource.tag</field>
-            <field name="arch" type="xml">
-                <form create="false">
-                    <sheet>
-                        <group>
-                            <field name="name"/>
-                        </group>
-                    </sheet>
-                </form>
-            </field>
-        </record>
+    <record id="view_resource_type_form" model="ir.ui.view">
+        <field name="name">resource.type.form</field>
+        <field name="model">resource.type</field>
+        <field name="arch" type="xml">
+            <form string="Resource Type" create="false">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="color_resource_type" widget="color_picker"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
 
-        <record id="view_resource_pivot" model="ir.ui.view">
-            <field name="name">resource.pivot</field>
-            <field name="model">resource</field>
-            <field name="arch" type="xml">
-                <pivot>
-                    <field name="resource_type"/>
-                    <field name="name"/>
-                </pivot>
-            </field>
-        </record>
+    <record id="view_resource_tag_tree" model="ir.ui.view">
+        <field name="name">resource.tag.tree</field>
+        <field name="model">resource.tag</field>
+        <field name="arch" type="xml">
+            <tree name="Resource Tags" editable="top">
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_resource_tag_form" model="ir.ui.view">
+        <field name="name">resource.tag.form</field>
+        <field name="model">resource.tag</field>
+        <field name="arch" type="xml">
+            <form create="false">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_resource_pivot" model="ir.ui.view">
+        <field name="name">resource.pivot</field>
+        <field name="model">resource</field>
+        <field name="arch" type="xml">
+            <pivot>
+                <field name="resource_type"/>
+                <field name="name"/>
+            </pivot>
+        </field>
+    </record>
 
 
-        <record id="action_resource_tag_act_window" model="ir.actions.act_window">
-            <field name="name">Resource Tag</field>
-            <field name="res_model">resource.tag</field>
-            <field name="view_mode">tree,form</field>
-            <field name="context"> {'no_breadcrumbs': True}</field>
-        </record>
+    <record id="action_resource_tag_act_window" model="ir.actions.act_window">
+        <field name="name">Resource Tag</field>
+        <field name="res_model">resource.tag</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'no_breadcrumbs': True}</field>
+    </record>
 
-        <record id="action_resource_type_act_window" model="ir.actions.act_window">
-            <field name="name">Resource Type</field>
-            <field name="res_model">resource.type</field>
-            <field name="view_mode">tree,form</field>
-            <field name="context"> {'no_breadcrumbs': True}</field>
-        </record>
+    <record id="action_resource_type_act_window" model="ir.actions.act_window">
+        <field name="name">Resource Type</field>
+        <field name="res_model">resource.type</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'no_breadcrumbs': True}</field>
+    </record>
 
-        <record id="action_resource_act_window"
-                model="ir.actions.act_window">
-            <field name="name">Resource</field>
-            <field name="res_model">resource</field>
-            <field name="view_mode">tree,form,pivot</field>
-            <field name="context"> {'no_breadcrumbs': True}</field>
-        </record>
+    <record id="action_resource_act_window"
+            model="ir.actions.act_window">
+        <field name="name">Resource</field>
+        <field name="res_model">resource</field>
+        <field name="view_mode">tree,form,pivot</field>
+        <field name="context">{'no_breadcrumbs': True}</field>
+    </record>
 </odoo>
 
 


### PR DESCRIPTION
[FIX] restriction

Users cannot create fields indirectly
- reformatted the code as well